### PR TITLE
Compatibility with django-cms plugin rendering

### DIFF
--- a/django_mustache/engine.py
+++ b/django_mustache/engine.py
@@ -79,7 +79,7 @@ class Template(object):
         if request:
             for fn in self.backend.template_context_processors:
                 contexts.append(fn(request))
-                
+
         contexts.append(context)
 
         return self.backend.engine.render(

--- a/django_mustache/engine.py
+++ b/django_mustache/engine.py
@@ -70,10 +70,16 @@ class Template(object):
         self.template = template
         self.backend = backend
 
-    def render(self, context, request):
+    def render(self, context, request=None):
         contexts = []
-        for fn in self.backend.template_context_processors:
-            contexts.append(fn(request))
+
+        if not request:
+            request = context.get('request', None)
+
+        if request:
+            for fn in self.backend.template_context_processors:
+                contexts.append(fn(request))
+                
         contexts.append(context)
 
         return self.backend.engine.render(


### PR DESCRIPTION
This PR adds compatibility with django-cms plugins so that mustache templates can be used as the render_template field for plugins. CMS Plugins supply the request as an attribute of the context rather than as a separate argument, this change enables that with a fallback to the original behaviour. 